### PR TITLE
Feat: Add copy buttons to text fields

### DIFF
--- a/src/app/common.blocks/panel/ControlConfigPanel.tsx
+++ b/src/app/common.blocks/panel/ControlConfigPanel.tsx
@@ -237,7 +237,7 @@ const ControlConfigPanelBody = observer((props: {}) => {
             visibility: app.selectedEntityCount === 1 && !(app.selectedControl instanceof EndControl) ? "hidden" : ""
           }}
           numeric
-          copyInfo={new CoordsCopyInfo(app.selectedControl!, clipboard.copyCoordsToClipboard, "ALL")}
+          copyInfo={new CoordsCopyInfo(app.selectedControl!, clipboard.copyCoordsToClipboard, "HEADING")}
         />
       </PanelBox>
       <PanelBox>

--- a/src/app/common.blocks/panel/ControlConfigPanel.tsx
+++ b/src/app/common.blocks/panel/ControlConfigPanel.tsx
@@ -2,7 +2,7 @@ import { Box, IconButton, Tooltip } from "@mui/material";
 import { action } from "mobx";
 import { observer } from "mobx-react-lite";
 import { AnyControl, Control, EndControl } from "@core/Path";
-import { FormInputField, clampQuantity } from "@app/component.blocks/FormInputField";
+import { CoordsCopyInfo, FormInputField, clampQuantity } from "@app/component.blocks/FormInputField";
 import { Quantity, UnitOfAngle, UnitOfLength } from "@core/Unit";
 import { boundHeading, findCentralPoint } from "@core/Calculation";
 import { Coordinate, CoordinateWithHeading, EuclideanTransformation, isCoordinateWithHeading } from "@core/Coordinate";
@@ -11,6 +11,7 @@ import { UpdatePathTreeItems } from "@core/Command";
 import { getAppStores } from "@core/MainApp";
 import { NumberUOA, NumberUOL } from "@token/Tokens";
 import { parseFormula } from "@core/Util";
+
 import FiberManualRecordIcon from "@mui/icons-material/FiberManualRecord";
 import FlipIcon from "@mui/icons-material/Flip";
 import RotateLeftIcon from "@mui/icons-material/RotateLeft";
@@ -19,11 +20,10 @@ import RotateRightIcon from "@mui/icons-material/RotateRight";
 import "./ControlConfigPanel.scss";
 import { PanelBox } from "@src/app/component.blocks/PanelBox";
 import { CoordinateSystemTransformation } from "@src/core/CoordinateSystem";
-import { enqueueErrorSnackbar, enqueueSuccessSnackbar } from "@src/app/Notice";
 import { Logger } from "@src/core/Logger";
 
 const ControlConfigPanelBody = observer((props: {}) => {
-  const { app } = getAppStores();
+  const { app, clipboard } = getAppStores();
 
   const logger = Logger("ControlConfigPanel");
 
@@ -115,22 +115,6 @@ const ControlConfigPanelBody = observer((props: {}) => {
     return new CoordinateSystemTransformation(cs, fieldDimension, firstControl);
   })();
 
-  const copyCoordsToClipboard = async (event?: React.UIEvent, x?: number, y?: number) => {
-    if (!document.hasFocus()) {
-      logger.log("Couldn't copy coordinates to clipboard -- window not focused");
-      enqueueErrorSnackbar(logger, "Couldn't copy coordinates!");
-
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(`${x ? x : xDisplayValue}, ${y ? y : yDisplayValue}`);
-      enqueueSuccessSnackbar(logger, "Copied coordinates to clipboard!");
-    } catch {
-      logger.error("Another unexpected error occurred when copying coords");
-    }
-  };
-
   let xDisplayValue: string;
   let yDisplayValue: string;
   let headingDisplayValue: string;
@@ -180,13 +164,17 @@ const ControlConfigPanelBody = observer((props: {}) => {
             );
 
             // copy coords to clipboard
-            copyCoordsToClipboard(undefined, newCoord.x, newCoord.y);
+            // clipboard.copyCoordsToClipboard({
+            //   "event": undefined,
+            //   "x": newCoord.x,
+            //   "y": newCoord.y,
+            // });
           }}
           isValidIntermediate={() => true}
           isValidValue={(candidate: string) => parseFormula(candidate, NumberUOL.parse) !== null}
           disabled={app.selectedEntityCount !== 1 || app.selectedControl === undefined}
           numeric
-          tooltipText="Click on me to copy coordinates!"
+          copyInfo={new CoordsCopyInfo(app.selectedControl!, clipboard.copyCoordsToClipboard, "POSITION")}
         />
         <FormInputField
           label="Y"
@@ -210,13 +198,17 @@ const ControlConfigPanelBody = observer((props: {}) => {
             );
 
             // copy coords to clipboard
-            copyCoordsToClipboard(undefined, newCoord.x, newCoord.y);
+            // clipboard.copyCoordsToClipboard({
+            //   "event": undefined,
+            //   "x": newCoord.x,
+            //   "y": newCoord.y,
+            // });
           }}
           isValidIntermediate={() => true}
           isValidValue={(candidate: string) => parseFormula(candidate, NumberUOL.parse) !== null}
           disabled={app.selectedEntityCount !== 1 || app.selectedControl === undefined}
           numeric
-          tooltipText="Click on me to copy coordinates!"
+          copyInfo={new CoordsCopyInfo(app.selectedControl!, clipboard.copyCoordsToClipboard, "POSITION")}
         />
         <FormInputField
           label="Heading"
@@ -245,6 +237,7 @@ const ControlConfigPanelBody = observer((props: {}) => {
             visibility: app.selectedEntityCount === 1 && !(app.selectedControl instanceof EndControl) ? "hidden" : ""
           }}
           numeric
+          copyInfo={new CoordsCopyInfo(app.selectedControl!, clipboard.copyCoordsToClipboard, "ALL")}
         />
       </PanelBox>
       <PanelBox>

--- a/src/app/component.blocks/FormInputField.tsx
+++ b/src/app/component.blocks/FormInputField.tsx
@@ -1,9 +1,13 @@
-import { TextField, TextFieldProps, Tooltip } from "@mui/material";
+import { Button, IconButton, InputAdornment, TextField, TextFieldProps, Tooltip } from "@mui/material";
 import { action } from "mobx";
 import { observer } from "mobx-react-lite";
 import { Quantity, UnitConverter, UnitOfLength } from "@core/Unit";
 import { clamp } from "@core/Util";
 import React, { forwardRef } from "react";
+import { AnyControl } from "@src/core/Path";
+
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import { CopyCoordsInfo } from "@src/core/Clipboard";
 
 export function clampQuantity(
   value: number,
@@ -17,19 +21,41 @@ export function clampQuantity(
   return clamp(value, minInUOL, maxInUOL).toUser();
 }
 
+export class CoordsCopyInfo {
+  /**
+   * The control to copy the coords of via `copyCallback`
+   */
+  public control: AnyControl;
+  /**
+   * The callback that will presumably copy the x- and y-coordinates in
+   * `control` to the clipboard
+   */
+  public copyCallback: (...args: any[]) => any;
+  /**
+   * Whether to copy just
+   */
+  public infoToCopy: CopyCoordsInfo;
+
+  constructor(controlArg: AnyControl, copyCallbackArg: (...args: any[]) => any, infoToCopy: CopyCoordsInfo) {
+    this.control = controlArg;
+    this.copyCallback = copyCallbackArg;
+    this.infoToCopy = infoToCopy;
+  }
+}
+
 export type FormInputFieldProps = TextFieldProps & {
   getValue: () => string;
   setValue: (value: string, payload: any) => void;
   isValidIntermediate: (candidate: string) => boolean;
   isValidValue: (candidate: string) => boolean | [boolean, any];
   numeric?: boolean; // default false
-  tooltipText?: string; // if provided, will show up when hover
+  copyInfo?: CoordsCopyInfo | boolean; // defaults to false
 };
 
 const FormInputField = observer(
   forwardRef<HTMLInputElement | null, FormInputFieldProps>((props: FormInputFieldProps, ref) => {
     // rest is used to send props to TextField without custom attributes
-    const { getValue, setValue, isValidIntermediate, isValidValue, numeric: isNumeric, tooltipText, ...rest } = props;
+    const { getValue, setValue, isValidIntermediate, isValidValue, numeric: isNumeric, copyInfo, ...rest } = props;
 
     const initialValue = React.useState(() => getValue())[0];
     const inputRef = React.useRef<HTMLInputElement>(null);
@@ -109,7 +135,51 @@ const FormInputField = observer(
       }
     }, [value, getValue]);
 
-    // return (
+    // if tooltip provided, wrap text input field within that
+    // return tooltipText ? (
+    //   <Tooltip title={tooltipText}>
+    //     <TextField
+    //       InputLabelProps={{ shrink: true }}
+    //       inputRef={inputRef}
+    //       size="small"
+    //       defaultValue={initialValue}
+    //       onChange={action(onChange)}
+    //       {...rest}
+    //       onKeyDown={action(onKeyDown)}
+    //       onBlur={action(onBlur)}
+    //       InputProps={{
+    //         endAdornment: (copyInfo instanceof CoordsCopyInfo) ? (
+    //           <InputAdornment position="end">
+    //             <Tooltip title="Copy to clipboard">
+    //               <IconButton onClick={(event: React.MouseEvent) => {
+    //                 copyInfo.copyCallback({
+    //                   event: event,
+    //                   control: copyInfo.control
+    //                 });
+    //               }} size="small" sx={{
+    //                 position: "absolute",
+    //                 top: 6,
+    //                 right: 6,
+    //                 opacity: 0.4,              // make it transparent
+    //                 pointerEvents: 'auto',     // allow hover
+    //                 transition: 'opacity 0.2s',
+    //                 '&:hover': {
+    //                   opacity: 1               // full opacity on hover
+    //                 }
+    //               }}>
+    //                 <ContentCopyIcon sx={{
+    //                   width: "10px",
+    //                   height: "10px",
+    //                   color: "#D3D3D3",
+    //                 }}></ContentCopyIcon>
+    //               </IconButton>
+    //             </Tooltip>
+    //           </InputAdornment>
+    //         ) : undefined
+    //       }}
+    //     />
+    //   </Tooltip>
+    // ) : (
     //   <TextField
     //     InputLabelProps={{ shrink: true }}
     //     inputRef={inputRef}
@@ -121,22 +191,7 @@ const FormInputField = observer(
     //     onBlur={action(onBlur)}
     //   />
     // );
-
-    // if tooltip provided, wrap text input field within that
-    return tooltipText ? (
-      <Tooltip title={tooltipText}>
-        <TextField
-          InputLabelProps={{ shrink: true }}
-          inputRef={inputRef}
-          size="small"
-          defaultValue={initialValue}
-          onChange={action(onChange)}
-          {...rest}
-          onKeyDown={action(onKeyDown)}
-          onBlur={action(onBlur)}
-        />
-      </Tooltip>
-    ) : (
+    return (
       <TextField
         InputLabelProps={{ shrink: true }}
         inputRef={inputRef}
@@ -146,6 +201,43 @@ const FormInputField = observer(
         {...rest}
         onKeyDown={action(onKeyDown)}
         onBlur={action(onBlur)}
+        InputProps={{
+          endAdornment:
+            copyInfo instanceof CoordsCopyInfo ? (
+              <InputAdornment position="end">
+                <Tooltip
+                  title={copyInfo.infoToCopy === "POSITION" ? "Copy x- and y-coordinates" : "Copy ENTIRE coordinate"}>
+                  <IconButton
+                    onClick={(event: React.MouseEvent) => {
+                      copyInfo.copyCallback({
+                        event: event,
+                        control: copyInfo.control,
+                        infoToCopy: copyInfo.infoToCopy
+                      });
+                    }}
+                    size="small"
+                    sx={{
+                      position: "absolute",
+                      top: 6,
+                      right: 6,
+                      opacity: 0.4, // make it transparent
+                      pointerEvents: "auto", // allow hover
+                      transition: "opacity 0.2s",
+                      "&:hover": {
+                        opacity: 1 // full opacity on hover
+                      }
+                    }}>
+                    <ContentCopyIcon
+                      sx={{
+                        width: "10px",
+                        height: "10px",
+                        color: "#D3D3D3"
+                      }}></ContentCopyIcon>
+                  </IconButton>
+                </Tooltip>
+              </InputAdornment>
+            ) : undefined
+        }}
       />
     );
   })

--- a/src/app/component.blocks/FormInputField.tsx
+++ b/src/app/component.blocks/FormInputField.tsx
@@ -1,4 +1,4 @@
-import { Button, IconButton, InputAdornment, TextField, TextFieldProps, Tooltip } from "@mui/material";
+import { IconButton, InputAdornment, TextField, TextFieldProps, Tooltip } from "@mui/material";
 import { action } from "mobx";
 import { observer } from "mobx-react-lite";
 import { Quantity, UnitConverter, UnitOfLength } from "@core/Unit";
@@ -32,7 +32,7 @@ export class CoordsCopyInfo {
    */
   public copyCallback: (...args: any[]) => any;
   /**
-   * Whether to copy just
+   * Whether to copy just x- and y- coordinates, or just heading
    */
   public infoToCopy: CopyCoordsInfo;
 
@@ -135,62 +135,6 @@ const FormInputField = observer(
       }
     }, [value, getValue]);
 
-    // if tooltip provided, wrap text input field within that
-    // return tooltipText ? (
-    //   <Tooltip title={tooltipText}>
-    //     <TextField
-    //       InputLabelProps={{ shrink: true }}
-    //       inputRef={inputRef}
-    //       size="small"
-    //       defaultValue={initialValue}
-    //       onChange={action(onChange)}
-    //       {...rest}
-    //       onKeyDown={action(onKeyDown)}
-    //       onBlur={action(onBlur)}
-    //       InputProps={{
-    //         endAdornment: (copyInfo instanceof CoordsCopyInfo) ? (
-    //           <InputAdornment position="end">
-    //             <Tooltip title="Copy to clipboard">
-    //               <IconButton onClick={(event: React.MouseEvent) => {
-    //                 copyInfo.copyCallback({
-    //                   event: event,
-    //                   control: copyInfo.control
-    //                 });
-    //               }} size="small" sx={{
-    //                 position: "absolute",
-    //                 top: 6,
-    //                 right: 6,
-    //                 opacity: 0.4,              // make it transparent
-    //                 pointerEvents: 'auto',     // allow hover
-    //                 transition: 'opacity 0.2s',
-    //                 '&:hover': {
-    //                   opacity: 1               // full opacity on hover
-    //                 }
-    //               }}>
-    //                 <ContentCopyIcon sx={{
-    //                   width: "10px",
-    //                   height: "10px",
-    //                   color: "#D3D3D3",
-    //                 }}></ContentCopyIcon>
-    //               </IconButton>
-    //             </Tooltip>
-    //           </InputAdornment>
-    //         ) : undefined
-    //       }}
-    //     />
-    //   </Tooltip>
-    // ) : (
-    //   <TextField
-    //     InputLabelProps={{ shrink: true }}
-    //     inputRef={inputRef}
-    //     size="small"
-    //     defaultValue={initialValue}
-    //     onChange={action(onChange)}
-    //     {...rest}
-    //     onKeyDown={action(onKeyDown)}
-    //     onBlur={action(onBlur)}
-    //   />
-    // );
     return (
       <TextField
         InputLabelProps={{ shrink: true }}

--- a/src/core/Clipboard.ts
+++ b/src/core/Clipboard.ts
@@ -22,12 +22,12 @@ type ClipboardMessageType = "SYNC_DATA" | "COPY_PATHS" | "COPY_CONTROLS";
  * "POSITION" copies just x and y to clipboard
  * "ALL" copies x, y, and heading to clipboard
  */
-export type CopyCoordsInfo = "POSITION" | "ALL";
+export type CopyCoordsInfo = "POSITION" | "HEADING";
 type CopyCoordsArgs = {
   event?: React.UIEvent;
   // x: number,
   // y: number,
-  control: EndControl;
+  control: AnyControl;
   infoToCopy: CopyCoordsInfo;
 };
 
@@ -347,14 +347,20 @@ export class AppClipboard {
   }
 
   public copyCoordsToClipboard = async (args: CopyCoordsArgs) => {
-    const { control, infoToCopy } = args;
+    let { control } = args;
+    const { infoToCopy } = args;
 
     try {
       let textToCopy = "";
       if (infoToCopy === "POSITION") {
         textToCopy = `${control.x.toFixed(3)}, ${control.y.toFixed(3)}`;
-      } else if (infoToCopy === "ALL") {
-        textToCopy = `${control.heading.toFixed(1)}`;
+      } else if (infoToCopy === "HEADING") {
+        // hopefully developers would only set "HEADING" on the proper
+        // controls' ConfigPanels... but just in case
+        if ("heading" in control) {
+          control = control as EndControl;
+          textToCopy = `${control.heading.toFixed(1)}`;
+        }
       }
       await navigator.clipboard.writeText(textToCopy);
       enqueueSuccessSnackbar(logger, "Copied to clipboard!");

--- a/src/core/Clipboard.ts
+++ b/src/core/Clipboard.ts
@@ -20,13 +20,11 @@ type ClipboardMessageType = "SYNC_DATA" | "COPY_PATHS" | "COPY_CONTROLS";
 
 /**
  * "POSITION" copies just x and y to clipboard
- * "ALL" copies x, y, and heading to clipboard
+ * "HEADING" copies x, y, and heading to clipboard
  */
 export type CopyCoordsInfo = "POSITION" | "HEADING";
 type CopyCoordsArgs = {
   event?: React.UIEvent;
-  // x: number,
-  // y: number,
   control: AnyControl;
   infoToCopy: CopyCoordsInfo;
 };
@@ -356,7 +354,7 @@ export class AppClipboard {
         textToCopy = `${control.x.toFixed(3)}, ${control.y.toFixed(3)}`;
       } else if (infoToCopy === "HEADING") {
         // hopefully developers would only set "HEADING" on the proper
-        // controls' ConfigPanels... but just in case
+        // controls' ConfigPanels (only those for `EndControl`s)... but just in case
         if ("heading" in control) {
           control = control as EndControl;
           textToCopy = `${control.heading.toFixed(1)}`;


### PR DESCRIPTION
Yippee! Now you don't have to accidentally trigger the copy function like 69420 times when you press on the text field a little bit too excitedly. This PR also fixes an issue where the code thinks you're "pressing" the text field (and thus copying) every time you refocus on the website window

This PR:
- refactors the copying function into `src/core/Clipboard.ts`
- adds the copy button as an `endAdornment` to the `FormInputField` component
- lots more fun typescripting!