### PR TITLE
v0.8.4 - Smart pasting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "path.jerryio",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "engines": {
     "node": "22.x",

--- a/src/Version.tsx
+++ b/src/Version.tsx
@@ -1,1 +1,1 @@
-export const APP_VERSION_STRING = "0.8.3";
+export const APP_VERSION_STRING = "0.8.4";

--- a/src/app/common.blocks/panel/ControlConfigPanel.tsx
+++ b/src/app/common.blocks/panel/ControlConfigPanel.tsx
@@ -220,7 +220,7 @@ const ControlConfigPanelBody = observer((props: {}) => {
             visibility: app.selectedEntityCount === 1 && !(app.selectedControl instanceof EndControl) ? "hidden" : ""
           }}
           numeric
-          copyInfo={new CoordsCopyInfo(app.selectedControl!, clipboard.copyCoordsToClipboard, "HEADING")}
+          copyInfo={new CoordsCopyInfo(app.selectedControl!, clipboard.copyCoordsToClipboard, "ALL")}
         />
       </PanelBox>
       <PanelBox>

--- a/src/core/Clipboard.ts
+++ b/src/core/Clipboard.ts
@@ -22,7 +22,7 @@ type ClipboardMessageType = "SYNC_DATA" | "COPY_PATHS" | "COPY_CONTROLS";
  * "POSITION" copies just x and y to clipboard
  * "HEADING" copies x, y, and heading to clipboard
  */
-export type CopyCoordsInfo = "POSITION" | "HEADING";
+export type CopyCoordsInfo = "POSITION" | "ALL";
 type CopyCoordsArgs = {
   event?: React.UIEvent;
   control: AnyControl;
@@ -352,12 +352,12 @@ export class AppClipboard {
       let textToCopy = "";
       if (infoToCopy === "POSITION") {
         textToCopy = `${control.x.toFixed(3)}, ${control.y.toFixed(3)}`;
-      } else if (infoToCopy === "HEADING") {
+      } else if (infoToCopy === "ALL") {
         // hopefully developers would only set "HEADING" on the proper
         // controls' ConfigPanels (only those for `EndControl`s)... but just in case
         if ("heading" in control) {
           control = control as EndControl;
-          textToCopy = `${control.heading.toFixed(1)}`;
+          textToCopy = `${control.x.toFixed(3)}, ${control.y.toFixed(3)}, ` + `${control.heading.toFixed(1)}`;
         }
       }
       await navigator.clipboard.writeText(textToCopy);

--- a/src/core/MainApp.ts
+++ b/src/core/MainApp.ts
@@ -38,8 +38,7 @@ const logger = Logger("App");
 // observable class
 export class MainApp {
   public format: Format =
-    getAllFormats().find(f => f.getName() === getPreference("lastSelectedFormat", "")) ??
-    new PathDotJerryioFormatV0_1();
+    getAllFormats().find(f => f.getName() === getPreference("lastSelectedFormat", "")) ?? new LemLibFormatV0_4();
   private usingUOL: UnitOfLength = UnitOfLength.Centimeter;
   public mountingFile: IOFileHandle = new IOFileHandle(null); // This is intended to be modified outside the class
 


### PR DESCRIPTION
what's smart pasting? basically, if you have a "coordinate string" (something of the form `<x>, <y>(, <heading>)`, where `<heading>` is optional -- essentially, something like `11.5, 57.005` or `23.633, 23.449, -215`), and you paste into the `ControlConfigPanel`... it will automatically replace the current control's x, y, and (optionally heading, if passed in) values with the string provided! so you don't have to copy and paste three times for every single point ;-;

# additional smaller fixes:
- automatically default to using the lemlib format for newly created paths
- fix clipboard not properly smart copying the entire coordinate (it would only copy heading beforehand ;-;)